### PR TITLE
The `live-html-preview` extention is broken

### DIFF
--- a/Week1/README.md
+++ b/Week1/README.md
@@ -86,9 +86,6 @@ In week one we will discuss the following topics
 
 - [Visual studio](https://code.visualstudio.com/)
 
-After you installed vscode, also install the following plugins
-- [Live HTML Previewer](https://marketplace.visualstudio.com/items?itemName=hdg.live-html-previewer)
-
 >Visual studio is the default text editor we use in the course. We expect you to use this editor through the entire course.
 
 ### Curriculum


### PR DESCRIPTION
Apparenly vscode has introduced some changes to their api `https://github.com/HarshdeepGupta/live-html-preview/issues/29`.

I also saw that it sometimes behaves a little different than standalone browsers when it comes to styling the `<html>` and `<body>` tags.

Proposing to remove this and make them use the real browser.