### PR TITLE
Changed the text OSX to macOS

### DIFF
--- a/Week0/README.md
+++ b/Week0/README.md
@@ -21,7 +21,7 @@ Have a look at this
 
 Please download the app for on your desktop:
 
-- [OSX](https://slack.com/downloads/osx)
+- [macOS](https://slack.com/downloads/mac)
 - [Windows](https://slack.com/downloads/windows)
 - [Linux](https://slack.com/downloads/linux)
 

--- a/Week0/README.md
+++ b/Week0/README.md
@@ -21,7 +21,7 @@ Have a look at this
 
 Please download the app for on your desktop:
 
-- [macOS](https://slack.com/downloads/mac)
+- [macOS](https://slack.com/downloads/mac) 
 - [Windows](https://slack.com/downloads/windows)
 - [Linux](https://slack.com/downloads/linux)
 


### PR DESCRIPTION
The OS name for mac desktops has been changed from OSX to macOS, so I did this minor change.